### PR TITLE
Set page control as a public readonly property

### DIFF
--- a/Classes/GoAutoSlideView.h
+++ b/Classes/GoAutoSlideView.h
@@ -79,6 +79,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) CGFloat indicatorBottomMargin;
 /**
+ * The page control of the slide view.
+ */
+@property (nonatomic, strong, readonly) UIPageControl *pageControl;
+/**
  *  Loads/Reloads the page view of the auto slide view.
  */
 - (void)reloadData;

--- a/Classes/GoAutoSlideView.m
+++ b/Classes/GoAutoSlideView.m
@@ -12,8 +12,6 @@
 
 @property (nonatomic, strong) NSTimer *slideTimer;
 
-@property (nonatomic, strong) UIPageControl *pageControl;
-
 @property (nonatomic, strong) NSMutableArray *contentViews;
 
 @property (nonatomic, strong) UIScrollView *scrollView;;
@@ -64,7 +62,7 @@
         return;
     }
     if (!self.pageControl) {
-        self.pageControl = [[UIPageControl alloc] init];
+        self->_pageControl = [[UIPageControl alloc] init];
         self.pageControl.hidesForSinglePage = YES;
         self.pageControl.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
         self.pageControl.center = CGPointMake(CGRectGetWidth(self.bounds) / 2, CGRectGetHeight(self.bounds) - (self.indicatorBottomMargin > 0 ? self.indicatorBottomMargin : 20));


### PR DESCRIPTION
iOS 14 introduces additional configurations to UIPageControl. Also, on iOS 14 the page control is not displayed because of the width.

Making the page control a public readonly property allows customization for iOS 14.